### PR TITLE
Show total number of hits in list

### DIFF
--- a/components/home/lists/lists-controller.js
+++ b/components/home/lists/lists-controller.js
@@ -263,6 +263,7 @@ trackerCapture.controller('ListsController',function(
         $scope.setServerResponse = function(serverResponse) {
             $scope.currentTrackedEntityList.data = TEIGridService.format($scope.selectedOrgUnit.id, serverResponse, false, $scope.base.optionSets, null);
             $scope.currentTrackedEntityList.loading = false;
+            $scope.pager = $scope.currentTrackedEntityList.data.pager
         };
 
         $scope.fetchTeis = function(pager, sortColumn){

--- a/components/home/lists/lists.html
+++ b/components/home/lists/lists.html
@@ -35,8 +35,12 @@
             <button class="btn btn-default"ng-click="showHideListColumns()" ng-attr-title="{{'show_hide_columns'| translate}}"><span class="fa fa-table"></span></button>
         </div>
 
-        <span ng-if="currentTrackedEntityList.data && pager.total">
+
+        <span ng-if="pager.total > -1">
             {{'total'| translate}}:  {{pager.total}}
+        </span>
+        <span ng-if="pager.total == -1">
+            {{'total'| translate}}:  ukjent
         </span>
         
         

--- a/components/home/lists/lists.html
+++ b/components/home/lists/lists.html
@@ -40,7 +40,7 @@
             {{'total'| translate}}:  {{pager.total}}
         </span>
         <span ng-if="pager.total == -1">
-            {{'total'| translate}}:  ukjent
+            {{'total'| translate}}:  ukjent / mer enn 1000
         </span>
         
         

--- a/d2-tracker/dhis2.angular.directives.js
+++ b/d2-tracker/dhis2.angular.directives.js
@@ -296,7 +296,8 @@ var d2Directives = angular.module('d2Directives', [])
 
             $scope.hasNextPage = function(){
                 var pager = $scope.pager;
-                return pager.recordsCount === pager.pageSize;
+                var isOnLastPage = pager.pageCount > 0 && pager.page >= pager.pageCount;
+                return pager.recordsCount === pager.pageSize && !isOnLastPage;
             }
 
             $scope.changePage = function(){

--- a/d2-tracker/templates/serverside-pagination-performant.html
+++ b/d2-tracker/templates/serverside-pagination-performant.html
@@ -1,7 +1,20 @@
 <div class="paging-container">
     <table style="background-color: #ebf0f6;" width='100%'>
+
         <tr>
             <td>
+            </td>
+            <td>
+                Viser {{pager.recordsCount}} av <span ng-if="pager.total > -1"> {{pager.total}}</span> <span ng-if="pager.total == -1"> over 1000</span> treff
+            </td>
+            <td>
+                Side {{pager.page}}<span ng-if="pager.pageCount && pager.total > -1"> av {{pager.pageCount}}</span>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+
             </td>
             <td>
                 <span>{{'rows_per_page'| translate}}:</span> <input type="text" min="1" style="width:50px;" ng-model="pageSizeEdit" d2-enter="changePageSize()" ng-blur="changePageSize()"> 

--- a/scripts/services.js
+++ b/scripts/services.js
@@ -2849,6 +2849,8 @@ i
                 existing[d[0]] = true;
                 return true;
             });
+            // Due to implementation, we cannot trust a number that is higher than 1000.
+            var totalElementsIfLessThanThousand = data.rows && data.rows.length  < 1000 ? data.rows.length : -1;
             var sortColumnIndex = data.headers.findIndex(function(h){ return h.name === sortColumn.id});
             if(sortColumnIndex) data.rows = orderByKeyFilter(data.rows, sortColumnIndex, sortColumn.direction);
             //order list
@@ -2856,6 +2858,7 @@ i
             workingList.cachedSorting = searchParams.sortUrl;
             workingList.cachedOrgUnit = searchParams.orgUnitId;
             var data = getCachedMultipleEventFiltersData(workingList, pager, sortColumn);
+            data.metaData.pager.total = totalElementsIfLessThanThousand;
             def.resolve(data);
         });
         return def.promise;
@@ -3155,6 +3158,7 @@ i
         }
     }
     var tetScopeSearchCount = this.tetScopeSearchCount = function(tetSearchGroup, trackedEntityType, orgUnit){
+        console.log('----? Getting scope search count?')
         var params = getSearchParams(tetSearchGroup, null, trackedEntityType, orgUnit, null, searchScopes.TET);
         if(params){
             return TEIService.searchCount(params.orgUnit.id, params.ouMode,null, params.programOrTETUrl, params.queryUrl, null, false).then(function(response){

--- a/scripts/services.js
+++ b/scripts/services.js
@@ -952,8 +952,9 @@ var trackerCaptureServices = angular.module('trackerCaptureServices', ['ngResour
             pgSize = pgSize > 1 ? pgSize  : 1;
             pg = pg > 1 ? pg : 1;
             url = url + '&pageSize=' + pgSize + '&page=' + pg;
+            // Not getting totalPages causes unpredictable bugs. Override and always get totalPages
             if(pager && pager.skipTotalPages) {
-                url+= '&totalPages=false';
+                url+= '&totalPages=true';
             }else{
                 url+= '&totalPages=true';
             }
@@ -2807,7 +2808,12 @@ i
     }
     var getCachedMultipleEventFiltersData = function(workingList, pager, sortColumn){
         var cachedData = cachedMultipleEventFiltersData[workingList.name];
-        if(!pager) pager = { page: 1, pageSize: 50, pageCount: Math.ceil(cachedData.rows.length/50)};
+        if(!pager) {
+            pager = { page: 1, pageSize: 50 }
+        };
+        // This has to be set explicitly, as it is randomly wrong otherwise.
+        pager.pageCount = Math.ceil(cachedData.rows.length/50)
+
         var pageEnd = (pager.pageSize*pager.page);
         var pageStart = pageEnd - pager.pageSize;
 
@@ -2859,6 +2865,7 @@ i
             workingList.cachedOrgUnit = searchParams.orgUnitId;
             var data = getCachedMultipleEventFiltersData(workingList, pager, sortColumn);
             data.metaData.pager.total = totalElementsIfLessThanThousand;
+            data.metaData.pager.pageCount = totalElementsIfLessThanThousand > 0 ? Math.ceil(totalElementsIfLessThanThousand/pager.pageSize) : 0
             def.resolve(data);
         });
         return def.promise;

--- a/scripts/services.js
+++ b/scripts/services.js
@@ -3165,7 +3165,6 @@ i
         }
     }
     var tetScopeSearchCount = this.tetScopeSearchCount = function(tetSearchGroup, trackedEntityType, orgUnit){
-        console.log('----? Getting scope search count?')
         var params = getSearchParams(tetSearchGroup, null, trackedEntityType, orgUnit, null, searchScopes.TET);
         if(params){
             return TEIService.searchCount(params.orgUnit.id, params.ouMode,null, params.programOrTETUrl, params.queryUrl, null, false).then(function(response){


### PR DESCRIPTION
* Calculate total number of hits in a combined search
* Set pager explicitly on data update to make sure it is up to date
* Show Total always, showing "ukjent" if it is unknown (due to how mixing results are done)
* Show total hits and number shown in pager
* Show total number of pages and current page
* Do not allow paging to next page if on actual last page
* Fix bugs where pager data becomes incorrect

Løser:

> Her i *kommune* ønsker vi at summen av antall nærkontakter og indekser som er under oppfølging kommer fram i tillegg til informasjonen om hvor mange som finnes på hver side. Hvis det befinner seg mellom 30 og 40 personer på lista er det ganske kjedelig å sitte å telle disse manuelt 
>  Dette er at hvis det er mindre enn 50 på siden så skal det stå det, rett å slett teller. Det kan også ses i sammenheng med å kunne se det totale antall registreringer på arbeidslisten
